### PR TITLE
Add TypeScript usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ module.exports = {
           lg: 1024,
           xl: 1192,
         },
+        interactions: {
+          hover: '(hover: hover)',
+          notHover: '(hover: none)',
+          landscape: 'not all and (orientation: landscape)',
+          portrait: 'not all and (orientation: portrait)',
+        },
       },
     },
   ],
@@ -60,3 +66,24 @@ See the [@artsy/fresnel README](https://github.com/artsy/fresnel) for full docum
 Note that this plugin utilizes the [`disableDynamicMediaQueries` option](https://github.com/artsy/fresnel#disabledynamicmediaqueries) from @artsy/fresnel to mitigate hydration mismatch errors introduced in React 18. As a result, all children of `Media` components will be rendered regardless of visibility.
 
 For more information, refer to [@artsy/fresnel's README section](https://github.com/artsy/fresnel#%EF%B8%8F-react-18-notice).
+
+## Usage with TypeScript
+
+If your project is using TypeScript, you can type annotate gatsby-plugin-fresnel's `Media` export to match your config.
+
+For example, given the [config above](#how-to-use), a `d.ts` file can be created in the project with the following contents:
+
+```ts
+declare module 'gatsby-plugin-fresnel' {
+  import type { CreateMediaResults } from '@artsy/fresnel/dist/Media';
+
+  // ensure that these match keys defined in gatsby-config.js
+  type BreakpointKey = 'sm' | 'md' | 'lg' | 'xl';
+  type InteractionKey = 'hover' | 'notHover' | 'landscape' | 'portrait';
+
+  export const Media: CreateMediaResults<
+    BreakpointKey,
+    InteractionKey
+  >['Media'];
+}
+```


### PR DESCRIPTION
This PR adds an example of using TypeScript with this plugin to the README.

I opted to have users define their own type annotations for a few reasons:
- `@artsy/fresnel` is a peer dependency of this plugin, so we have no way of consuming its types in our own definitions
- the `at` and `interaction` props of the `Media` component should be defined based on a project's config defined in `gatsby-config.js`. Since we have no way of inferring these types based on a user's config, the need to define themselves

The example provided has users explicitly redefine `BreakpointKey` and `InteractionKey`, maintaining parity with `gatsby-config.js`. There may be a more elegant way for users to define their config in TypeScript and have these types be inferred from that, though I'm not sure what the status of importing TS modules in `gatsby-config` is - open to PRs exploring that.

Importing `CreateMediaResults` from `@artsy/fresnel/dist/Media` is somewhat fragile as fresnel's upstream exports may eventually change, though I'm not sure what a great alternative is. Perhaps we could consume the main `createMedia` export and somehow derive `Media` based on that? For now, I'm okay with updating this example if that export ever breaks.